### PR TITLE
Updated to support Gradle versions >= 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ buildscript {
      		 url "https://plugins.gradle.org/m2/"
     	}
     	dependencies {
-            classpath "net.ltgt.gradle:gradle-apt-plugin:0.19"
             classpath "gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:1.4.0"
             classpath "com.diffplug.spotless:spotless-plugin-gradle:3.24.2"
         }
@@ -42,7 +41,6 @@ apply plugin: 'java'
 apply plugin: 'application'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
-apply plugin: "net.ltgt.apt"
 apply plugin: 'com.google.cloud.tools.jib'
 apply plugin: "com.diffplug.gradle.spotless"
 
@@ -72,16 +70,16 @@ mainClassName = System.getProperty('mainClass', 'com.google.solutions.df.video.a
 
 
 dependencies {
-    compile group: 'org.apache.beam', name: 'beam-sdks-java-core', version: dataflowBeamVersion
-    compile group: 'org.apache.beam', name: 'beam-runners-google-cloud-dataflow-java', version:dataflowBeamVersion
-    compile group: 'org.apache.beam', name: 'beam-runners-direct-java', version: dataflowBeamVersion
-    compile group: 'org.apache.beam', name: 'beam-sdks-java-extensions-ml', version: dataflowBeamVersion
-    compile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.30'
-    compile "com.google.auto.value:auto-value-annotations:1.6.2"
-	compile 'com.google.cloud:google-cloud-video-intelligence:1.2.1'
+    implementation group: 'org.apache.beam', name: 'beam-sdks-java-core', version: dataflowBeamVersion
+    implementation group: 'org.apache.beam', name: 'beam-runners-google-cloud-dataflow-java', version:dataflowBeamVersion
+    implementation group: 'org.apache.beam', name: 'beam-runners-direct-java', version: dataflowBeamVersion
+    implementation group: 'org.apache.beam', name: 'beam-sdks-java-extensions-ml', version: dataflowBeamVersion
+    implementation group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.30'
+    implementation "com.google.auto.value:auto-value-annotations:1.6.2"
+	implementation 'com.google.cloud:google-cloud-video-intelligence:1.2.1'
     annotationProcessor "com.google.auto.value:auto-value:1.6.2"
-    testCompile group: 'org.apache.beam', name: 'beam-runners-direct-java', version: dataflowBeamVersion
-    testCompile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.30'
+    testImplementation group: 'org.apache.beam', name: 'beam-runners-direct-java', version: dataflowBeamVersion
+    testImplementation group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.30'
 }
 
 


### PR DESCRIPTION
The GCP Cloud Console currently uses Gradle 7.4 by default and the build fails.